### PR TITLE
literal needs quotes or it will be parsed as a variable - which will not...

### DIFF
--- a/gitlab/packages.sls
+++ b/gitlab/packages.sls
@@ -87,7 +87,7 @@ gitlab-deps:
       - python-docutils
       - redis-server
       - zlib1g-dev
-      {% if salt['pillar.get']('gitlab:db_engine', postgresql) == 'postgresql' %}
+      {% if salt['pillar.get']('gitlab:db_engine', 'postgresql') == 'postgresql' %}
       - libpq-dev
       {% endif %}
 {% endif %}


### PR DESCRIPTION
... exist

to avoid this:

```
Local:
    Data failed to compile:
----------
    No matching sls found for 'gitlab' in env 'base'
----------
    Rendering SLS "base:gitlab.packages" failed: Jinja variable 'postgresql' is undefined; line 93

---
[...]
      - openssh-server
      - python
      - python-docutils
      - redis-server
      - zlib1g-dev
      {% if salt['pillar.get']('gitlab:db_engine', postgresql) == 'postgresql' %}    <======================
      - libpq-dev
      {% endif %}
{% endif %}

{% if salt['pillar.get']('gitlab:use_rvm', False) %}
[...]
```
