### PR TITLE
runner: replace symlink with cp for upstart

### DIFF
--- a/gitlab/runner.sls
+++ b/gitlab/runner.sls
@@ -32,9 +32,9 @@ gitlab-install_runserver3:
       - user: gitlab-install_runserver_create_user
 
 gitlab-create_init_file:
-  file.symlink:
+  file.copy:
     - name: "/etc/init/gitlab-runner.conf"
-    - target: "/opt/gitlab-runner/doc/install/upstart/gitlab-runner.conf"
+    - source: "/opt/gitlab-runner/doc/install/upstart/gitlab-runner.conf"
     - user: "root" 
     - group: "root" 
     - mode: 775 

--- a/gitlab/runner.sls
+++ b/gitlab/runner.sls
@@ -39,6 +39,7 @@ gitlab-create_init_file:
     - group: "root" 
     - mode: 775 
     - unless: 'test -e /etc/init/gitlab-runner.conf'
+    - force: True
     - require:
       - cmd: gitlab-install_runserver3
 


### PR DESCRIPTION
https://bugs.launchpad.net/upstart/+bug/665022/comments/3

This commit fixes error: 

    Service gitlab-runner is already enabled, and is dead